### PR TITLE
Directly exposing Strategy via module.exports

### DIFF
--- a/lib/passport-twitch/index.js
+++ b/lib/passport-twitch/index.js
@@ -14,3 +14,5 @@ require('pkginfo')(module, 'version');
  */
 exports.Strategy =
 exports.OAuth2Strategy = OAuth2Strategy;
+
+exports = module.exports = OAuth2Strategy;


### PR DESCRIPTION
The documentation does not make it clear that in order to use this strategy, you must do this:

`var TwitchStrategy = require('passport-twitch').Strategy;`

It's possible to directly expose the strategy by using `module.exports`, like [`passport-local`](https://github.com/jaredhanson/passport-local/blob/master/lib/index.js#L10) does.

If this pull request is not accepted, the documentation should be updated to reflect that to use this, it must be declared as stated above, instead of simply requiring the module.
