### PR TITLE
Add support for `force_verify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ app.get("/auth/twitch/callback", passport.authenticate("twitch", { failureRedire
 });
 ```
 
+Optionally, the `forceVerify` option can be set to `true` to indicate
+that the user should be re-prompted for authorization:
+
+```javascript
+app.get("/auth/twitch", passport.authenticate("twitch", {forceVerify: true}));
+```
+
 ## Example
 
 ```javascript

--- a/lib/passport-twitch/oauth2.js
+++ b/lib/passport-twitch/oauth2.js
@@ -95,6 +95,21 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 };
 
 /**
+ * Return extra parameters to be included in the authorization request.
+ *
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+Strategy.prototype.authorizationParams = function(options) {
+    var params = {};
+    if (typeof options.forceVerify !== "undefined") {
+        params.force_verify = !!options.forceVerify;
+    }
+    return params;
+};
+
+/**
  * Expose `Strategy`.
  */
 module.exports = Strategy;


### PR DESCRIPTION
Adds support for the `force_verify` option as shown in the [official documentation](https://github.com/justintv/Twitch-API/blob/master/authentication.md#authorization-code-flow).
