### PR TITLE
Update to new Twitch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ passport.use(new twitchStrategy({
     clientID: TWITCH_CLIENT_ID,
     clientSecret: TWITCH_CLIENT_SECRET,
     callbackURL: "http://127.0.0.1:3000/auth/twitch/callback",
-    scope: "user_read"
+    scope: "user:read:email analytics:read:games"
   },
   function(accessToken, refreshToken, profile, done) {
     User.findOrCreate({ twitchId: profile.id }, function (err, user) {
@@ -92,7 +92,7 @@ passport.use(new twitchStrategy({
     clientID: "098f6bcd4621d373cade4e832627b4f6",
     clientSecret: "4eb20288afaed97e82bde371260db8d8",
     callbackURL: "http://127.0.0.1:3000/auth/twitch/callback",
-    scope: "user_read"
+    scope: "user:read:email analytics:read:games"
   },
   function(accessToken, refreshToken, profile, done) {
     // Suppose we are using mongo..

--- a/lib/passport-twitch/oauth2.js
+++ b/lib/passport-twitch/oauth2.js
@@ -42,13 +42,13 @@ var InternalOAuthError = require("passport-oauth2").InternalOAuthError;
  */
 function Strategy(options, verify) {
     options = options || {};
-    options.authorizationURL = options.authorizationURL || "https://api.twitch.tv/kraken/oauth2/authorize";
-    options.tokenURL = options.tokenURL || "https://api.twitch.tv/kraken/oauth2/token";
+    options.authorizationURL = options.authorizationURL || "https://id.twitch.tv/oauth2/authorize";
+    options.tokenURL = options.tokenURL || "https://id.twitch.tv/oauth2/token";
 
     OAuth2Strategy.call(this, options, verify);
     this.name = "twitch";
 
-    this._oauth2.setAuthMethod("OAuth");
+    this._oauth2.setAuthMethod("Bearer");
     this._oauth2.useAuthorizationHeaderforGET(true);
 }
 
@@ -72,15 +72,15 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-    this._oauth2.get("https://api.twitch.tv/kraken/user", accessToken, function (err, body, res) {
+    this._oauth2.get("https://api.twitch.tv/helix/users", accessToken, function (err, body, res) {
         if (err) { return done(new InternalOAuthError("failed to fetch user profile", err)); }
 
         try {
-            var json = JSON.parse(body);
+            var json = JSON.parse(body).data[0];
 
             var profile = { provider: "twitch" };
-            profile.id = json._id;
-            profile.username = json.name;
+            profile.id = json.id;
+            profile.username = json.login;
             profile.displayName = json.display_name;
             profile.email = json.email;
 
@@ -106,6 +106,7 @@ Strategy.prototype.authorizationParams = function(options) {
     if (typeof options.forceVerify !== "undefined") {
         params.force_verify = !!options.forceVerify;
     }
+    params.response_type = options.response_type || "token+id_token";
     return params;
 };
 

--- a/lib/passport-twitch/oauth2.js
+++ b/lib/passport-twitch/oauth2.js
@@ -106,7 +106,6 @@ Strategy.prototype.authorizationParams = function(options) {
     if (typeof options.forceVerify !== "undefined") {
         params.force_verify = !!options.forceVerify;
     }
-    params.response_type = options.response_type || "token+id_token";
     return params;
 };
 


### PR DESCRIPTION
EDIT 2: A fork has been made and published to npm at https://github.com/Nigh7Sh4de/passport-twitch-new

EDIT: To those stumbling across this and need to use this _now_, you can fork my repo and use 

> "passport-twitch": "github:GithubUsername/passport-twitch"

 to use the new Twitch API until this PR gets merged.

Original message:

Twitch API V5 is deprecated, and will be removed at the end of the year.
This PR updates the endpoints and strategy to the new Twitch API.

@Schmoopiie 
I suggest that this PR goes in a separate branch and is published under a beta tag on NPM because it is not backward compatible because of the changes made to how scopes work, and because not all scopes have been implemented in the new API yet.