### PR TITLE
fix: remove pkgInfo dependency to allow webpack bundling 

### DIFF
--- a/lib/passport-twitch/index.js
+++ b/lib/passport-twitch/index.js
@@ -1,15 +1,9 @@
 /**
  * Module dependencies.
  */
-var OAuth2Strategy = require("./oauth2");
-
-/**
- * Framework version.
- */
-require("pkginfo")(module, "version");
+var OAuth2Strategy = require('./oauth2');
 
 /**
  * Expose constructors.
  */
-exports.Strategy =
-exports.OAuth2Strategy = OAuth2Strategy;
+exports.Strategy = exports.OAuth2Strategy = OAuth2Strategy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "passport-twitch",
+  "version": "1.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
+    "diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vows": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.4.tgz",
+      "integrity": "sha1-/w7V1lTQTTl87jLc5DhOqIy08ZM=",
+      "dev": true,
+      "requires": {
+        "diff": "~1.0.3",
+        "eyes": ">=0.1.6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   ],
   "main": "./lib/passport-twitch",
   "dependencies": {
-    "passport-oauth2": "^1.1.2",
-    "pkginfo": "0.2.x"
+    "passport-oauth2": "^1.1.2"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
pkgInfo fails when trying to bundle this package using Webpack. This pull request removes that dependency.